### PR TITLE
Fixes for mounting loopback devices on F2FS partitions

### DIFF
--- a/fs/f2fs/dir.c
+++ b/fs/f2fs/dir.c
@@ -517,7 +517,7 @@ void f2fs_update_dentry(nid_t ino, umode_t mode, struct f2fs_dentry_ptr *d,
 	de->ino = cpu_to_le32(ino);
 	set_de_type(de, mode);
 	for (i = 0; i < slots; i++)
-		test_and_set_bit_le(bit_pos + i, (void *)d->bitmap);
+		__set_bit_le(bit_pos + i, (void *)d->bitmap);
 }
 
 /*

--- a/fs/f2fs/file.c
+++ b/fs/f2fs/file.c
@@ -1719,6 +1719,8 @@ long f2fs_compat_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 const struct file_operations f2fs_file_operations = {
 	.llseek		= f2fs_llseek,
+	.read		= new_sync_read,
+	.write		= new_sync_write,
 	.read_iter	= generic_file_read_iter,
 	.write_iter	= f2fs_file_write_iter,
 	.open		= f2fs_file_open,

--- a/fs/f2fs/inline.c
+++ b/fs/f2fs/inline.c
@@ -509,7 +509,7 @@ void f2fs_delete_inline_entry(struct f2fs_dir_entry *dentry, struct page *page,
 	inline_dentry = inline_data_addr(page);
 	bit_pos = dentry - inline_dentry->dentry;
 	for (i = 0; i < slots; i++)
-		test_and_clear_bit_le(bit_pos + i,
+		__clear_bit_le(bit_pos + i,
 				&inline_dentry->dentry_bitmap);
 
 	set_page_dirty(page);


### PR DESCRIPTION
Mounting an raw image under a f2fs-formated partition (e.g. /data) as a loopback device fails due to missing read/write pointers. 

Reference: https://forum.xda-developers.com/showpost.php?p=70492947&postcount=8793